### PR TITLE
Re-adding the 'contact' field

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ helper: ["Gloria Li", "Julia Gustavsen"]
 contact1: nsoontie@eos.ubc.ca
 contact2: blackburn@science.ubc.ca
 etherpad: https://etherpad.mozilla.org/2015-03-05-ubc
-
+contact: nsoontie@eos.ubc.ca
 ---
 <!--
   HEADER


### PR DESCRIPTION
We need a field in the header called 'contact' in order to stitch this page into the main web site - it's OK to have other fields like 'contact1' and 'contact2', but 'contact' has to be there.  You can run 'tools/check' before committing changes to make sure that everything's OK - if that was giving the page a clean bill of health when it didn't have a 'contact' field, please let me know and I'll track down the bug.
Please mail me when this page is updated and I'll try incorporating it into the main website.
Thanks,
Greg
